### PR TITLE
Extract rubocop test into command which is ran on CI

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -39,6 +39,9 @@ jobs:
         RAILS_ENV: test
       run: |
         bundle exec rails db:test:prepare
+    - name: Run rubocop
+      run: |
+        bundle exec rubocop
     - name: Run ruby tests
       env:
         PGHOST: 127.0.0.1

--- a/test/linters/rubocop_test.rb
+++ b/test/linters/rubocop_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class RubocopTest < ActiveSupport::TestCase
-  test 'everything formatted according to rubocop' do
-    assert_match(/no\ offenses\ detected/, `rubocop`)
-  end
-end


### PR DESCRIPTION
The output is more readable if a rubocop check fails.